### PR TITLE
Add VersionSupport functions for OreoMR1 and Pie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+* VersionUtils: Support functions for OreoMR1(27) and Pie(28)
+
+### Changed
+### Removoed
+### Fixed
+
 ## [1.4.0] - 2019-04-05
 ### Added
 * AndroidX support

--- a/seventools/src/main/java/me/sieben/seventools/utils/VersionSupport.kt
+++ b/seventools/src/main/java/me/sieben/seventools/utils/VersionSupport.kt
@@ -5,6 +5,14 @@ package me.sieben.seventools.utils
 
 import android.os.Build
 
+fun isAtLeast28Pie() = Build.VERSION_CODES.P.isSupported()
+
+inline fun isAtLeast28Pie(noinline unsupported: (() -> Unit)? = null, supported: () -> Unit) = if (isAtLeast28Pie()) supported() else unsupported?.invoke()
+
+fun isAtLeast27OreoMR1() = Build.VERSION_CODES.O_MR1.isSupported()
+
+inline fun isAtLeast27OreoMR1(noinline unsupported: (() -> Unit)? = null, supported: () -> Unit) = if (isAtLeast27OreoMR1()) supported() else unsupported?.invoke()
+
 fun isAtLeast26Oreo() = Build.VERSION_CODES.O.isSupported()
 
 inline fun isAtLeast26Oreo(noinline unsupported: (() -> Unit)? = null, supported: () -> Unit) = if (isAtLeast26Oreo()) supported() else unsupported?.invoke()


### PR DESCRIPTION
Add VersionSupport function analog to the other function for _OreoMR1_ and _Pie_.