### PR TITLE
Add missing log leve Info and add throwable param

### DIFF
--- a/seventools/src/main/java/me/sieben/seventools/utils/Logger.kt
+++ b/seventools/src/main/java/me/sieben/seventools/utils/Logger.kt
@@ -5,34 +5,30 @@ package me.sieben.seventools.utils
 import android.util.Log
 
 @Deprecated("For development only!", ReplaceWith("this"))
-fun <T> T.io(msg: String = "", tag: String = "logIo"): T = apply {
-    Log.d(tag, "$msg <$this>")
+fun <T> T.io(msg: String = "", tag: String = "logIo", throwable: Throwable? = null): T = apply {
+    Log.d(tag, "$msg <$this>", throwable)
 }
 
-fun <T> T.verb(msg: String = "", tag: String = "logVerbose"): T = apply {
-    Log.v(tag, "$msg <$this>")
+fun <T> T.verb(msg: String = "", tag: String = "logVerbose", throwable: Throwable? = null): T = apply {
+    Log.v(tag, "$msg <$this>", throwable)
 }
 
-fun <T> T.dbg(msg: String = "", tag: String = "logDebug"): T = apply {
-    Log.d(tag, "$msg <$this>")
+fun <T> T.dbg(msg: String = "", tag: String = "logDebug", throwable: Throwable? = null): T = apply {
+    Log.d(tag, "$msg <$this>", throwable)
 }
 
-fun <T> T.warn(msg: String = "", tag: String = "logWarn"): T = apply {
-    Log.w(tag, "$msg <$this>")
+fun <T> T.info(msg: String = "", tag: String = "logInfo", throwable: Throwable? = null): T = apply {
+    Log.i(tag, "$msg <$this>", throwable)
 }
 
-fun <T> T.err(msg: String = "", tag: String = "logError"): T = apply {
-    Log.e(tag, "$msg <$this>")
+fun <T> T.warn(msg: String = "", tag: String = "logWarn", throwable: Throwable? = null): T = apply {
+    Log.w(tag, "$msg <$this>", throwable)
 }
 
-fun <T> T.wtf(msg: String = "", tag: String = "logWtf"): T = apply {
-    Log.wtf(tag, "$msg <$this>")
+fun <T> T.err(msg: String = "", tag: String = "logError", throwable: Throwable? = null): T = apply {
+    Log.e(tag, "$msg <$this>", throwable)
 }
 
-fun <T> T.wtf(throwable: Throwable, tag: String = "logWtf"): T = apply {
-    Log.wtf(tag, "<$this>", throwable)
-}
-
-fun <T> T.wtf(msg: String = "", throwable: Throwable, tag: String = "logWtf"): T = apply {
+fun <T> T.wtf(msg: String = "", tag: String = "logWtf", throwable: Throwable? = null): T = apply {
     Log.wtf(tag, "$msg <$this>", throwable)
 }


### PR DESCRIPTION
I added the throwable parameter to all logging wrapper functions, because they support.  
Obsolete wrapping functions has been removed.  
The default for the throwable is null so it can be omitted.